### PR TITLE
Move theme assembly names into appsettings.json

### DIFF
--- a/src/Epistle/Program.cs
+++ b/src/Epistle/Program.cs
@@ -38,7 +38,12 @@ builder.Services.Configure<MvcRazorRuntimeCompilationOptions>
 (
     options =>
     {
-        options.FileProviders.Insert(0, new EmbeddedFileProvider(Assembly.Load("Epistle.Theme.Default")));
+        var index = 0;
+        var assemblies = builder.Configuration.GetValue<IEnumerable<string>>("Themes:Assemblies")!;
+        foreach (var assembly in assemblies)
+        {
+            options.FileProviders.Insert(index++, new EmbeddedFileProvider(Assembly.Load(assembly)));
+        }
     }
 );
 

--- a/src/Epistle/appsettings.json
+++ b/src/Epistle/appsettings.json
@@ -3,7 +3,12 @@
     "ConnectionString": "mongodb://localhost:27017",
     "Database": "Epistle"
   },
-  "Theme": "Epistle.Theme.Default",
+  "Themes": {
+    "Assemblies": [
+      "Epistle.Theme.Default"
+    ],
+    "Selected": "Default"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
- Move theme assembly names into appsettings.json
- Multiple theme assemblies may be loaded, precedence respected
- Selected theme name is configurable but not yet used

resolves #10