### PR TITLE
Unit tests for filter to prevent unwanted spidering

### DIFF
--- a/src/Epistle.Tests.Unit/Epistle.Tests.Unit.csproj
+++ b/src/Epistle.Tests.Unit/Epistle.Tests.Unit.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Epistle\Epistle.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Epistle.Tests.Unit/Filters/TestArachnophobiaAsyncActionFilter.cs
+++ b/src/Epistle.Tests.Unit/Filters/TestArachnophobiaAsyncActionFilter.cs
@@ -1,0 +1,71 @@
+using Epistle.Filters;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+
+namespace Epistle.Tests.Unit.Filters;
+
+[TestClass]
+public class TestArachnophobiaAsyncActionFilter
+{
+    [TestMethod]
+    public async Task TestArachnophobic()
+    {
+        await TestArachnophobicByConfig("true", Assert.IsTrue);
+    }
+
+    [TestMethod]
+    public async Task TestNotArachnophobic()
+    {
+        await TestArachnophobicByConfig("false", Assert.IsFalse);
+    }
+
+    private async Task TestArachnophobicByConfig(string configSetting, Action<bool> assertion)
+    {
+        var mockConfigService = new Mock<IConfiguration>();
+        var mockConfigSection = new Mock<IConfigurationSection>();
+        mockConfigSection.Setup(cs => cs.Value).Returns(configSetting);
+        mockConfigService.Setup(cs => cs.GetSection("Arachnophobic")).Returns(mockConfigSection.Object);
+        var actionFilter = new ArachnophobiaAsyncActionFilter(mockConfigService.Object);
+
+        var httpContext = new DefaultHttpContext();
+        var actionContext = new ActionContext
+        (
+            httpContext,
+            new RouteData(),
+            new ActionDescriptor(),
+            new ModelStateDictionary()
+        );
+        var actionExecutingContext = new ActionExecutingContext
+        (
+            actionContext,
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object?>(),
+            null!
+        );
+        var actionExecutedContext = new ActionExecutedContext
+        (
+            actionContext,
+            new List<IFilterMetadata>(),
+            null!
+        );
+
+        await actionFilter.OnActionExecutionAsync(actionExecutingContext, () => Task.Run(() => actionExecutedContext));
+
+        var headers = httpContext?.Response?.Headers;
+        Assert.IsNotNull(headers);
+
+        var robots = headers.Where(x => x.Key.Equals("X-Robots-Tag", StringComparison.OrdinalIgnoreCase));
+        foreach (var robot in robots)
+        {
+            string val = robot.Value!;
+            assertion(val.Contains("noindex"));
+            assertion(val.Contains("nofollow"));
+            assertion(val.Contains("noarchive"));
+        }
+    }
+}

--- a/src/Epistle.Tests.Unit/Usings.cs
+++ b/src/Epistle.Tests.Unit/Usings.cs
@@ -1,0 +1,5 @@
+﻿global using Epistle.ActivityPub;
+global using Epistle.Controllers;
+global using Epistle.Services;
+global using Moq;
+global using Object = Epistle.ActivityPub.Object;

--- a/src/Epistle.sln
+++ b/src/Epistle.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Epistle.Domain", "Epistle.D
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Epistle.Theme.Default", "Epistle.Theme.Default\Epistle.Theme.Default.csproj", "{62CE64B0-467E-4A59-A502-407372FB0076}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Epistle.Tests.Unit", "Epistle.Tests.Unit\Epistle.Tests.Unit.csproj", "{A8AC1BDA-6DF4-40FF-B377-FE919B13578B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{62CE64B0-467E-4A59-A502-407372FB0076}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{62CE64B0-467E-4A59-A502-407372FB0076}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{62CE64B0-467E-4A59-A502-407372FB0076}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8AC1BDA-6DF4-40FF-B377-FE919B13578B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8AC1BDA-6DF4-40FF-B377-FE919B13578B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8AC1BDA-6DF4-40FF-B377-FE919B13578B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8AC1BDA-6DF4-40FF-B377-FE919B13578B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- Create new unit test project
- Create two new unit tests for filter
  - Test filter adds header when configuration setting is true
  - Test filter does not add header when configuration setting is false

Resolves #19 